### PR TITLE
Fix/macos brew owner detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -395,20 +395,8 @@ install_suricata_macos() {
         return 1
     fi
     
-    if brew_command install --formula "$SURICATA_RP_PATH"; then
-        info_message "Suricata installed successfully"
-        
-        if brew_command pin suricata; then
-            info_message "Suricata pinned successfully"
-        else
-            warn_message "Failed to pin Suricata version"
-        fi
-        
-        success_message "Suricata v${version} built and installed from source on macOS successfully"
-    else
-        error_message "Failed to install Suricata from formula"
-        return 1
-    fi
+    brew_command install --formula "$SURICATA_RP_PATH"
+    brew_command pin suricata
     
     info_message "Cleaning up formula file..."
     sudo -u "$LOGGED_IN_USER" rm -f "$SURICATA_RP_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,7 @@ SURICATA_VERSION_MACOS=${SURICATA_VERSION_MACOS:-"7.0.10"}
 DOWNLOADS_DIR="${HOME}/suricata-install"
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    LOGGED_IN_USER=$(stat -f "%Su" "$(brew --prefix)")
+    LOGGED_IN_USER=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ {print $3}')
 fi
 
 # Command Existence Check

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,15 @@ SURICATA_VERSION_MACOS=${SURICATA_VERSION_MACOS:-"7.0.10"}
 DOWNLOADS_DIR="${HOME}/suricata-install"
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    LOGGED_IN_USER=$(stat -f "%Su" "$(brew --prefix)")
+    if ! BREW_PREFIX=$(brew --prefix 2>/dev/null); then
+        echo "Error: Failed to get brew prefix. Is Homebrew installed?" >&2
+        exit 1
+    fi
+    
+    if ! LOGGED_IN_USER=$(stat -f "%Su" "$BREW_PREFIX" 2>/dev/null); then
+        echo "Error: Failed to get owner of brew prefix ($BREW_PREFIX). Check if the directory exists and is accessible." >&2
+        exit 1
+    fi
 fi
 
 # Command Existence Check

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,7 +59,7 @@ sed_alternative() {
 }
 
 brew_command() {
-    sudo -u "$LOGGED_IN_USER" brew "$@"
+    sudo -u "$LOGGED_IN_USER" -i brew "$@"
 }
 
 mkdir -p "$DOWNLOADS_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,6 +103,22 @@ init_brew_env() {
         BREW_OWNER="$(/usr/bin/stat -f '%Su' "$BREW_PREFIX" 2>/dev/null || echo "unknown")"
     fi
 }
+
+brew_available() {
+  init_brew_env
+  [ -n "$BREW_BIN" ] && [ -x "$BREW_BIN" ] && [ -n "$BREW_OWNER" ] && [ "$BREW_OWNER" != "root" ]
+}
+
+require_brew_or_exit() {
+  if ! brew_available; then
+    error_exit "Homebrew not available (or owner undetected). Install Homebrew as a regular user first."
+  fi
+}
+
+brew_command() {
+  require_brew_or_exit
+  sudo -H -u "$BREW_OWNER" env NONINTERACTIVE=1 PATH="$(dirname "$BREW_BIN"):/usr/bin:/bin:/usr/sbin:/sbin" "$BREW_BIN" "$@"
+}
 # ---------- end Homebrew helpers ----------
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -380,19 +380,38 @@ remove_brew_suricata() {
 
 install_suricata_macos() {
     local version="$1"
-    info_message "Installing Suricata v${version} from source on macOS" ""
+    info_message "Installing Suricata v${version} from source on macOS"
+    
     SURICATA_RB_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/1adc97dc5122276de00d8081a5497bb6b5381b0c/Formula/s/suricata.rb" #v7.0.10
-    SURICATA_RP_PATH="$DOWNLOADS_DIR/suricata.rb"
-
-    curl -SL --progress-bar "$SURICATA_RB_URL" -o "$SURICATA_RP_PATH" || {
+    
+    USER_HOME=$(eval echo "~$LOGGED_IN_USER")
+    SURICATA_RP_PATH="$USER_HOME/suricata.rb"
+    
+    info_message "Downloading Suricata formula to user directory..."
+    if sudo -u "$LOGGED_IN_USER" curl -SL --progress-bar "$SURICATA_RB_URL" -o "$SURICATA_RP_PATH"; then
+        info_message "Suricata formula downloaded successfully"
+    else
         error_message "Failed to download suricata.rb file"
-        exit 1
-    }
-
-    brew_command install --formula "$SURICATA_RP_PATH"
-    brew_command pin suricata
-
-    success_message "Suricata v${version} built and installed from source on macOS successfully"
+        return 1
+    fi
+    
+    if brew_command install --formula "$SURICATA_RP_PATH"; then
+        info_message "Suricata installed successfully"
+        
+        if brew_command pin suricata; then
+            info_message "Suricata pinned successfully"
+        else
+            warn_message "Failed to pin Suricata version"
+        fi
+        
+        success_message "Suricata v${version} built and installed from source on macOS successfully"
+    else
+        error_message "Failed to install Suricata from formula"
+        return 1
+    fi
+    
+    info_message "Cleaning up formula file..."
+    sudo -u "$LOGGED_IN_USER" rm -f "$SURICATA_RP_PATH"
 }
 
 install_suricata_darwin() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -392,7 +392,7 @@ install_suricata_macos() {
         info_message "Suricata formula downloaded successfully"
     else
         error_message "Failed to download suricata.rb file"
-        return 1
+        exit 1
     fi
     
     brew_command install --formula "$SURICATA_RP_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,7 @@ SURICATA_VERSION_MACOS=${SURICATA_VERSION_MACOS:-"7.0.10"}
 DOWNLOADS_DIR="${HOME}/suricata-install"
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    LOGGED_IN_USER=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ {print $3}')
+    LOGGED_IN_USER=$(stat -f "%Su" "$(brew --prefix)")
 fi
 
 # Command Existence Check


### PR DESCRIPTION
Closes Issue: https://github.com/ADORSYS-GIS/wazuh-yara/issues/51
Key Changes:

- Added -i flag to brew_command() for proper environment isolation
- Download .rb files to user's home directory (/Users/username/) instead of root's (/var/root/)
- User now has proper access to both Homebrew cache and formula files